### PR TITLE
make it possible to replace ENV with SecretPuller

### DIFF
--- a/gem/lib/samson_secret_puller.rb
+++ b/gem/lib/samson_secret_puller.rb
@@ -5,17 +5,20 @@ module SamsonSecretPuller
   class TimeoutError < StandardError
   end
 
+  ENV = ENV # store a copy since we might replace ENV on Object
+
   class << self
-    def [](key)
-      secrets[key]
+    extend Forwardable
+    [:[], :fetch, :keys, :each, :include?].each do |method|
+      def_delegator :secrets, method
     end
 
-    def fetch(*args, &block)
-      secrets.fetch(*args, &block)
+    def []=(key, value)
+      ENV[key] = secrets[key] = value
     end
 
-    def keys
-      secrets.keys
+    def to_h
+      secrets
     end
 
     private

--- a/gem/test/samson_secret_puller_test.rb
+++ b/gem/test/samson_secret_puller_test.rb
@@ -132,4 +132,27 @@ describe SamsonSecretPuller do
       SamsonSecretPuller.keys.must_include 'HOME'
     end
   end
+
+  describe '.to_h' do
+    it "generates a complete hash" do
+      SamsonSecretPuller.to_h["FOO"].must_equal "bar"
+    end
+  end
+
+  describe '[]=' do
+    it "writes into the environment and secrets" do
+      SamsonSecretPuller["BAR"] = 'baz'
+      ENV["BAR"].must_equal 'baz'
+      SamsonSecretPuller["BAR"].must_equal 'baz'
+    end
+  end
+
+  describe '.each' do
+    it "iterates all" do
+      found = []
+      SamsonSecretPuller.each { |k, v| found << [k, v] }
+      found.must_include ["FOO", "bar"]
+      found.must_include ["HOME", ENV["HOME"]]
+    end
+  end
 end


### PR DESCRIPTION
having to go deep into every app and make everything read from Secrets would be pretty annoying and easy to miss since it will work in dev and test ... so we override ENV with secrets and make it transparent without exposing secrets to sub-processes.

@zendesk/paas 