### PR TITLE
Change docker container name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ ENV['FOO'] -> read from /secrets/FOO or falls back to ENV['FOO']
 ```
 ... build ...
 docker build -t samson-secret-puller .
-docker tag samson-secret-puller docker-registry.zende.sk/samson-secret-puller:latest
-docker push docker-registry.zende.sk/samson-secret-puller:latest
+docker tag samson-secret-puller docker-registry.zende.sk/secret_sidecar:latest
+docker push docker-registry.zende.sk/secret_sidecar:latest
 ```
 
 


### PR DESCRIPTION
Changes the docker container name to the one used by Samson.

@jonmoter @grosser 