### PR TITLE
Add key? to the list of delegated methods

### DIFF
--- a/gem/lib/samson_secret_puller.rb
+++ b/gem/lib/samson_secret_puller.rb
@@ -9,7 +9,7 @@ module SamsonSecretPuller
 
   class << self
     extend Forwardable
-    [:[], :fetch, :keys, :each, :include?, :delete, :each_with_object, :values_at].each do |method|
+    [:[], :fetch, :keys, :each, :key?, :include?, :delete, :each_with_object, :values_at].each do |method|
       def_delegator :secrets, method
     end
 


### PR DESCRIPTION
Our team is trying to use `samson_secret_puller` in a Rails 5 application using Puma. The following exception is thrown on startup when calling `replace_ENV!`

```
=> Booting Puma
=> Rails 5.0.0.1 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
Exiting
/usr/local/lib/ruby/gems/2.3.0/gems/puma-3.6.0/lib/puma/events.rb:35:in `initialize': undefined method `key?' for SamsonSecretPuller:Module (NoMethodError)
Did you mean?  keys
    from /usr/local/lib/ruby/gems/2.3.0/gems/puma-3.6.0/lib/puma/events.rb:145:in `new'
    from /usr/local/lib/ruby/gems/2.3.0/gems/puma-3.6.0/lib/puma/events.rb:145:in `stdio'
    from /usr/local/lib/ruby/gems/2.3.0/gems/puma-3.6.0/lib/rack/handler/puma.rb:45:in `run'
    from /usr/local/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:296:in `start'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/server.rb:79:in `start'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:90:in `block in server'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:85:in `tap'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:85:in `server'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
    from /usr/local/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
    from bin/rails:9:in `require'
    from bin/rails:9:in `<main>'
```

Adding `key?` to the list of delegated methods seems to suffice to fix it.

/cc @irwaters @grosser @henders @benhass @smithzd @rgueldem 
