### PR TITLE
Add Golang secret puller

### DIFF
--- a/go-samson-secret-puller/secrets.go
+++ b/go-samson-secret-puller/secrets.go
@@ -1,0 +1,36 @@
+package samsonsecretpuller
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+// Secrets returns a map of secret names and values
+func Secrets() (map[string]string, error) {
+	s, err := readSecrets("/secrets")
+	return s, err
+}
+
+func readSecrets(d string) (map[string]string, error) {
+	s := make(map[string]string)
+	files, err := ioutil.ReadDir(d)
+
+	if err != nil {
+		return s, err
+	}
+
+	for _, file := range files {
+		n := file.Name()
+		if strings.HasPrefix(n, ".") {
+			continue
+		}
+		data, err := ioutil.ReadFile(filepath.Join(d, n))
+		if err != nil {
+			return s, err
+		}
+		s[n] = strings.TrimSpace(string(data))
+	}
+
+	return s, err
+}

--- a/go-samson-secret-puller/secrets_test.go
+++ b/go-samson-secret-puller/secrets_test.go
@@ -1,0 +1,34 @@
+package samsonsecretpuller
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestReading(t *testing.T) {
+	s := []byte("agent\n")
+	dir, err := ioutil.TempDir("", "secrets")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "hemmelig"), s, 0644); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, ".done"), s, 0644); err != nil {
+		log.Fatal(err)
+	}
+
+	expected := map[string]string{"hemmelig": "agent"}
+	secrets, _ := readSecrets(dir)
+
+	if !reflect.DeepEqual(secrets, expected) {
+		t.Errorf("Expected %v, got %v", expected, secrets)
+	}
+}


### PR DESCRIPTION
I am using Go for a project that I'd like to deploy to Kubernetes in the not-too-distant future. This PR adds a secret puller that's usable from that project.

Naturally I welcome feedback on the code (I am still pretty new to Go) but I am also interested in whether you think this code should even be included in this project. For instance, it would be nice to run the test on Travis, but it seems silly to make the Docker image install Go just to run a test in one of the consumers (actually I am surprised we do that for the Elixir consumer). Maybe that means the code should live elsewhere?

@grosser, @irwaters
@zendesk/enigma 
