### PR TITLE
remove quote deletion since it is fail-slow

### DIFF
--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -168,7 +168,7 @@ class SecretsClient
   end
 
   def vault_path(key)
-    (VAULT_SECRET_BACKEND + SAMSON_SECRET_NAMESPACE + key).delete('"')
+    VAULT_SECRET_BACKEND + SAMSON_SECRET_NAMESPACE + key
   end
 
   def secrets_from_annotations(annotations)


### PR DESCRIPTION
no idea why ian added that, but I'd rather get rid of it and fail wherever we introduced quotes by accident

@zendesk/compute 
/cc @ragurney 