### PR TITLE
support reading mount and prefix from env, also only accept 1/true as…

### DIFF
--- a/bin/secrets
+++ b/bin/secrets
@@ -1,27 +1,20 @@
 #!/usr/bin/env ruby
 STDOUT.sync = true
-require_relative "../lib/secrets.rb"
+require_relative "../lib/secrets"
 
-vault_address = ENV.fetch("VAULT_ADDR") || raise("VAULT_ADDR not provided")
-vault_auth_file = ENV["VAULT_AUTH_FILE"] || '/vault-auth/authsecret'
-vault_tls_verify = ['1', 'true'].include?(ENV["VAULT_TLS_VERIFY"])
-sidecar_secret_path = ENV["SIDECAR_SECRET_PATH"] || '/secrets'
-annotations = ENV["SECRET_ANNOTATIONS"] || '/secretkeys/annotations'
-serviceaccount_dir = ENV["SERVICEACCOUNT_DIR"] || '/var/run/secrets/kubernetes.io/serviceaccount/'
-api_host = ENV.fetch("KUBERNETES_PORT_443_TCP_ADDR")
-scheme = 'https://'
-scheme = 'http://' if ENV["TESTING"]
-api_url = scheme + api_host
+true_env = ['1', 'true']
 
 client = SecretsClient.new(
-  vault_address: vault_address,
-  authfile_path: vault_auth_file,
-  ssl_verify: vault_tls_verify,
-  annotations: annotations,
-  serviceaccount_dir: serviceaccount_dir,
-  output_path: sidecar_secret_path,
-  api_url: api_url,
-  v2: ENV["VAULT_KV_V2"]
+  vault_address: ENV.fetch("VAULT_ADDR") || raise("VAULT_ADDR not provided"),
+  vault_mount: ENV["VAULT_MOUNT"] || "secret",
+  vault_prefix: ENV["VAULT_PREFIX"] || "apps",
+  vault_authfile_path: ENV["VAULT_AUTH_FILE"] || '/vault-auth/authsecret',
+  ssl_verify: true_env.include?(ENV["VAULT_TLS_VERIFY"]),
+  annotations: ENV["SECRET_ANNOTATIONS"] || '/secretkeys/annotations',
+  serviceaccount_dir: ENV["SERVICEACCOUNT_DIR"] || '/var/run/secrets/kubernetes.io/serviceaccount/',
+  output_path: ENV["SIDECAR_SECRET_PATH"] || '/secrets',
+  api_url: (ENV["TESTING"] ? 'http://' : 'https://') + ENV.fetch("KUBERNETES_PORT_443_TCP_ADDR"),
+  vault_v2: true_env.include?(ENV["VAULT_KV_V2"])
 )
 
 client.write_secrets

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -23,18 +23,20 @@ describe SecretsClient do
   let(:client_options) do
     {
       vault_address: 'https://foo.bar:8200',
-      authfile_path: 'token',
+      vault_authfile_path: 'token',
+      vault_prefix: 'apps',
+      vault_mount: 'secret',
       ssl_verify: false,
       annotations: 'annotations',
       serviceaccount_dir: Dir.pwd,
       output_path: Dir.pwd,
       api_url: 'https://foo.bar',
-      v2: false
+      vault_v2: false
     }
   end
   let(:token_client) { SecretsClient.new(client_options) }
   let(:client) do
-    client_options[:authfile_path] = "vaultpem"
+    client_options[:vault_authfile_path] = "vaultpem"
     SecretsClient.new(client_options)
   end
   let(:auth_reply) { {auth: {client_token: 'sometoken'}}.to_json }
@@ -130,7 +132,7 @@ describe SecretsClient do
     end
 
     it 'can read v2' do
-      client_options[:v2] = true
+      client_options[:vault_v2] = true
       url.sub!('/apps', '/data/apps') || raise
       request = stub_request(:get, url).to_return(response_body({data: {data: {vault: 'foo'}}}.to_json))
 


### PR DESCRIPTION
… truthy for kv-v2

goes with https://github.com/zendesk/samson/pull/3122

@zendesk/compute @zendesk/bre 