### PR TITLE
PAAS-2712 read address and kv-v2 from mounter secret if it provides that

### DIFF
--- a/bin/secrets
+++ b/bin/secrets
@@ -4,8 +4,24 @@ require_relative "../lib/secrets"
 
 true_env = ['1', 'true']
 
+vault_address_file = '/vault-auth/authsecret'
+vault_address =
+  if File.exist?(vault_address_file)
+    File.read(vault_address_file).strip
+  else
+    ENV.fetch("VAULT_ADDR")
+  end
+
+vault_kv_version_file = '/vault-auth/kv_version'
+vault_v2 =
+  if File.exist?(vault_kv_version_file)
+    File.read(vault_kv_version_file).strip == "2"
+  else
+    true_env.include?(ENV["VAULT_KV_V2"])
+  end
+
 client = SecretsClient.new(
-  vault_address: ENV.fetch("VAULT_ADDR") || raise("VAULT_ADDR not provided"),
+  vault_address: vault_address,
   vault_mount: ENV["VAULT_MOUNT"] || "secret",
   vault_prefix: ENV["VAULT_PREFIX"] || "apps",
   vault_authfile_path: ENV["VAULT_AUTH_FILE"] || '/vault-auth/authsecret',
@@ -14,7 +30,7 @@ client = SecretsClient.new(
   serviceaccount_dir: ENV["SERVICEACCOUNT_DIR"] || '/var/run/secrets/kubernetes.io/serviceaccount/',
   output_path: ENV["SIDECAR_SECRET_PATH"] || '/secrets',
   api_url: (ENV["TESTING"] ? 'http://' : 'https://') + ENV.fetch("KUBERNETES_PORT_443_TCP_ADDR"),
-  vault_v2: true_env.include?(ENV["VAULT_KV_V2"])
+  vault_v2: vault_v2
 )
 
 client.write_secrets


### PR DESCRIPTION
we want to migrate the address/kv-v2 into the secret so it has all the information and we do not end
up reading with the wrong token when we switch over vault servers

adding .strip calls because I don't trust kubernetes to get it right :)

@zendesk/compute 