### PR TITLE
show address and version we are connecting to improve debuggability

### DIFF
--- a/bin/secrets
+++ b/bin/secrets
@@ -21,6 +21,8 @@ vault_v2 =
     true_env.include?(ENV["VAULT_KV_V2"])
   end
 
+puts "Connecting to address: #{vault_address} v2: #{vault_v2}"
+
 client = SecretsClient.new(
   vault_address: vault_address,
   vault_mount: ENV["VAULT_MOUNT"] || "secret",


### PR DESCRIPTION
already had 2 bugs with this were we spend >1 hour each figuring out what was wrong :/

@zendesk/compute @aglover-zendesk 

confirmed working with `kubectl logs foo -c secret-puller -n default  --context bar`
`Connecting to address: https://foo:8200 v2: false`