### PR TITLE
CONFIG-436 Adds support for ip and hostname in PKI certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ VAULT_PREFIX: optional, which prefix to use, defaults to "apps"
 SIDECAR_SECRET_PATH: optional, where to store the secrets on disk, defaults to  '/secrets'
 SECRET_ANNOTATIONS: optional, where to read annotations from, defaults to '/secretkeys/annotations'
 SERVICEACCOUNT_DIR: optional, where to service account from, defaults to '/var/run/secrets/kubernetes.io/serviceaccount/'
+POD_IP: optional, the IP address assigned to the Kubernetes pod
+POD_HOSTNAME: optional, the hostname assigned to the Kubernetes pod
 ```
 
 **(secrets in repo work only for testing)**.
@@ -28,12 +30,12 @@ SERVICEACCOUNT_DIR: optional, where to service account from, defaults to '/var/r
 Example config:
  - [kubernetes/vault-auth-secret.yml](kubernetes/vault-auth-secret.yml)
  - [kubernetes/vault-auth-token.yml](kubernetes/vault-auth-token.yml)
- 
+
 #### Supported Authentication Types
 ##### `VAULT_AUTH_TYPE=token` (default)
 
 The file path specified in `VAULT_AUTH_FILE` will be read and used as a Vault token directly.
-The token is validated using Vault's [lookup-self API](https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-). 
+The token is validated using Vault's [lookup-self API](https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-).
 
 ##### `VAULT_AUTH_TYPE=cert`
 
@@ -45,7 +47,7 @@ If the backend is mounted at a different path from `/auth/cert`, it can be custo
 
 ##### `VAULT_AUTH_TYPE=kubernetes`
 
-The Kubernetes ServiceAccount mounted into the init container will be used to  
+The Kubernetes ServiceAccount mounted into the init container will be used to
 authenticate with vault using the [Kubernetes Auth backend](https://www.vaultproject.io/api/auth/kubernetes/index.html).
 The role against which login will be attempted is set via `VAULT_AUTH_ROLE`.
 
@@ -95,6 +97,12 @@ ${SIDECAR_SECRET_PATH}/pki/example.com/serial_number
 ${SIDECAR_SECRET_PATH}/pki/example.com/private_key_type
 ${SIDECAR_SECRET_PATH}/pki/example.com/expiration
 ```
+
+**Special Annotation Parameters:**
+
+- `?pod_hostname_as_cn=true`: Pod hostname is set to the common name, overriding the `common_name` parameter if provided
+- `?pod_hostname_as_san=true`: Pod hostname is included as a subject alternate name
+- `?pod_ip_as_san=true`: Pod IP is included as a subject alternate name
 
 ### Debugging
 

--- a/bin/secrets
+++ b/bin/secrets
@@ -52,6 +52,8 @@ client = SecretsClient.new(
   serviceaccount_dir: ENV["SERVICEACCOUNT_DIR"] || '/var/run/secrets/kubernetes.io/serviceaccount/',
   output_path: ENV["SIDECAR_SECRET_PATH"] || '/secrets',
   api_url: (ENV["TESTING"] ? 'http://' : 'https://') + ENV.fetch("KUBERNETES_PORT_443_TCP_ADDR"),
+  pod_ip: ENV["POD_IP"],
+  pod_hostname: ENV["POD_HOSTNAME"],
   vault_v2: vault_v2,
   logger: logger
 )

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -53,7 +53,8 @@ describe "CLI" do
         SIDECAR_SECRET_PATH: Dir.pwd,
         SERVICEACCOUNT_DIR: Dir.pwd,
         SECRET_ANNOTATIONS: 'input',
-        KUBERNETES_PORT_443_TCP_ADDR: "localhost:#{port}"
+        KUBERNETES_PORT_443_TCP_ADDR: "localhost:#{port}",
+        POD_HOSTNAME: 'example.com'
       ) do
         sh "#{Bundler.root}/bin/secrets"
         File.read('BAR').must_equal('foo') # secret was written out
@@ -71,7 +72,8 @@ describe "CLI" do
         SIDECAR_SECRET_PATH: Dir.pwd,
         SERVICEACCOUNT_DIR: Dir.pwd,
         SECRET_ANNOTATIONS: 'input',
-        KUBERNETES_PORT_443_TCP_ADDR: "localhost:#{port}"
+        KUBERNETES_PORT_443_TCP_ADDR: "localhost:#{port}",
+        POD_HOSTNAME: 'example.com'
       ) do
         sh "#{Bundler.root}/bin/secrets"
         File.read('BAR').must_equal('foo') # secret was written out


### PR DESCRIPTION
Updates Vault PKI integration by adding support for encoding Kubernetes
Pod IP address and Hostname into the issued certificate. This functionality
facilitates mutual TLS between networked services with hostname validation.

Pod IP address can be given to the secret puller via the environment variable
`POD_IP` (possibly through use of the k8s downward API), if omitted, the 
secret puller will attempt lookup of the container's IP address.

Pod Hostname can be given to the secret puller via the environment variable
`POD_HOSTNAME`, if omitted, the secret puller will attempt to lookup the
container's hostname. 

The Pod IP address can be encoded in the issued certificate as a subject
alternate name when the parameter `pod_ip_as_san=true` is included in the
PKI annotation's value. The Pod Hostname can be encoded as the common
name in the issued certificate when the parameter `pod_hostname_as_cn=true`
is included in the PKI annotation's value (**Note:** when this parameter
is defined it will override the value of the `common_name` parameter).
Likewise, the Pod Hostname can be encoded as a subject alternate name
in the issued certificate when the parameter `pod_hostname_as_san=true`
is included in the PKI annotation. This interface has been defined in the 
README.

**Fixes:**
* Discovered incorrect handling of `ca_chain` data attribute in the Generate
  Certificate Vault API response. Fixed typo `s/chain_ca/ca_chain`. This also
  affects the name of the file written to the the output path.