### PR TITLE
simplify hostname to not crash

### DIFF
--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -38,7 +38,7 @@ class SecretsClient
     @ssl_verify = ssl_verify
     @vault_v2 = vault_v2
     @pod_ip = find_pod_ip_v4 pod_ip
-    @pod_hostname = pod_hostname || Socket.gethostbyname(Socket.gethostname).first
+    @pod_hostname = pod_hostname || Socket.gethostname
     @logger = logger
 
     @vault = Vault::Client.new(


### PR DESCRIPTION
seeing that in internaltools a lot
```
SocketError: getaddrinfo: Name does not resolve
  /app/lib/secrets.rb:41:in `gethostbyname'
```
this version works though ... also returns the same value as before, so idk why this was ever added

fixup for https://github.com/zendesk/samson_secret_puller/pull/80

@zendesk/compute
/cc @arecker 