### PR TITLE
silence/disable pki writing when there are no keys

### DIFF
--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -99,6 +99,8 @@ class SecretsClient
   end
 
   def write_pki_certs
+    return if @pki_keys.empty? # silence / do less work
+
     errors = []
     pkis = @pki_keys.map do |name, path|
       begin

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -333,6 +333,13 @@ describe SecretsClient do
       File.read("pki/test.com/expiration").must_equal(expiration)
     end
 
+    it 'does nothing without keys' do
+      File.write('annotations', <<~TEXT)
+        secret/SECRET="this/is/very/hidden"
+      TEXT
+      process_pki_certs
+    end
+
     context 'exercise #split_url' do
       before do
         stub_request(:put, +'https://foo.bar:8200/v1/pki/issue/request-empty').


### PR DESCRIPTION
saying that something was written when there were none / going though all that logic seems kinda wrong 🤷‍♂ 
... also I never saw any of this work, is this even used ?
@nateradtke @aglover-zendesk 
/cc @zendesk/secure 