### PR TITLE
Make service account dir required only for kubernetes auth

### DIFF
--- a/elixir/lib/samson_secret_puller.ex
+++ b/elixir/lib/samson_secret_puller.ex
@@ -25,7 +25,7 @@ defmodule SamsonSecretPuller do
   ## Examples
 
       iex> SamsonSecretPuller.fetch_secrets!("./test/doc_secrets")
-      [MYSQL_PASS: "password", MYSQL_USER: "admin"]
+      [MYSQL_USER: "admin", MYSQL_PASS: "password"]
 
   """
   @spec fetch_secrets!(Path.t) :: Keyword.t | no_return

--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -27,7 +27,7 @@ class SecretsClient
   )
     raise ArgumentError, "vault address not found" if vault_address.nil?
     raise ArgumentError, "annotations file not found" unless File.exist?(annotations.to_s)
-    raise ArgumentError, "serviceaccount dir #{serviceaccount_dir} not found" unless Dir.exist?(serviceaccount_dir.to_s)
+    raise ArgumentError, "serviceaccount dir #{serviceaccount_dir} not found" if !Dir.exist?(serviceaccount_dir.to_s) && vault_auth_type == "kubernetes"
     raise ArgumentError, "api_url is null" if api_url.nil?
 
     @vault_mount = vault_mount

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -39,7 +39,7 @@ describe SecretsClient do
       vault_mount: 'secret',
       ssl_verify: false,
       annotations: 'annotations',
-      serviceaccount_dir: Dir.pwd,
+      serviceaccount_dir: 'foo',
       output_path: Dir.pwd,
       api_url: 'https://foo.bar',
       vault_v2: false,
@@ -51,6 +51,7 @@ describe SecretsClient do
   let(:token_client) { SecretsClient.new(client_options) }
   let(:serviceaccount_client) do
     client_options[:vault_auth_type] = "kubernetes"
+    client_options[:serviceaccount_dir] = Dir.pwd
     SecretsClient.new(client_options)
   end
   let(:client) do
@@ -128,7 +129,7 @@ describe SecretsClient do
     end
 
     it "fails to initialize when serviceaccount_dir is missing" do
-      assert_raises(ArgumentError) { SecretsClient.new(client_options.merge(serviceaccount_dir: "foo")) }
+      assert_raises(ArgumentError) { SecretsClient.new(client_options.merge(serviceaccount_dir: "foo", vault_auth_type: "kubernetes")) }
     end
   end
 


### PR DESCRIPTION
# Description

Samson secret puller checks for `/var/run/secrets/kubernetes.io` directory even if `token` auth method is in use. We should make it required only for `kubernetes` auth method. 
I have modified tests assumptions accordingly.

```
[04:18:41]   {"severity":"INFO","message":"Connecting to vault","address":"https://secret.zdsystest.com:8200";,"v2":true}
[04:18:41]   bundler: failed to load command: bin/secrets (bin/secrets)
[04:18:41]   ArgumentError: serviceaccount dir /var/run/secrets/kubernetes.io/serviceaccount/ not found
[04:18:41]     /app/lib/secrets.rb:30:in `initialize'
[04:18:41]     bin/secrets:42:in `new'
[04:18:41]     bin/secrets:42:in `<top (required)>'
```

# JIRA
https://zendesk.atlassian.net/browse/FS-1071

/cc @grosser @adammw @swaller-zendesk 