### PR TITLE
Ignore directories when reading from filesystem

### DIFF
--- a/gem/lib/samson_secret_puller.rb
+++ b/gem/lib/samson_secret_puller.rb
@@ -65,8 +65,14 @@ module SamsonSecretPuller
 
     def read_secrets
       return {} unless File.exist?(FOLDER)
-      Dir.glob("#{FOLDER}/*").each_with_object({}) do |file, all|
+      scan_folder.each_with_object({}) do |file, all|
         all[File.basename(file)] = File.read(file).strip
+      end
+    end
+
+    def scan_folder
+      Dir.glob("#{FOLDER}/*").reject do |path|
+        File.directory?(path)
       end
     end
   end

--- a/gem/test/samson_secret_puller_test.rb
+++ b/gem/test/samson_secret_puller_test.rb
@@ -52,6 +52,7 @@ describe SamsonSecretPuller do
   before do
     # basic healthy status
     Dir.mkdir('secrets')
+    Dir.mkdir('secrets/dir')
     File.write('secrets/FOO', 'bar')
     File.write('secrets/.done', 'd')
 
@@ -59,6 +60,10 @@ describe SamsonSecretPuller do
     if SamsonSecretPuller.instance_variable_defined?(:@secrets)
       SamsonSecretPuller.remove_instance_variable(:@secrets)
     end
+  end
+
+  it "ignores directories" do
+    SamsonSecretPuller['dir'].must_be_nil
   end
 
   it "reads secrets" do


### PR DESCRIPTION
Currently the gem would fail with
```
Errno::EISDIR: Is a directory @ io_fread - secrets/dir
```
if there is a sub-directory inside the default `/secrets` directory.

This change will make the gem ignore directories instead of failing.

Cc: @zendesk/wallaby @zendesk/lyrebird @zendesk/echidna 