### PR TITLE
SRE: reduce redundant logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SECRET_ANNOTATIONS: optional, where to read annotations from, defaults to '/secr
 SERVICEACCOUNT_DIR: optional, where to service account from, defaults to '/var/run/secrets/kubernetes.io/serviceaccount/'
 POD_IP: optional, the IP address assigned to the Kubernetes pod
 POD_HOSTNAME: optional, the hostname assigned to the Kubernetes pod
+LOG_LEVEL: optional, log level, defaults to "info"; set to "debug" when debugging
 ```
 
 **(secrets in repo work only for testing)**.
@@ -109,6 +110,7 @@ ${SIDECAR_SECRET_PATH}/pki/example.com/expiration
  - Use a dedicated Pod to debug inside the cluster, see [kubernetes/debug.yml]
  - There is no `bash`, use `sh`
  - (GCR) See which commit the image has `docker inspect --format '{{ index .Config.Labels "revision"}}' <image-name>`
+ - set `LOG_LEVEL=debug` env var for debug logs
 
 ### Test
 

--- a/bin/secrets
+++ b/bin/secrets
@@ -6,7 +6,7 @@ STDOUT.sync = true
 # json logging so it can be indexed
 require 'logger'
 require 'json'
-logger = Logger.new($stdout, level: Logger::INFO)
+logger = Logger.new($stdout, level: ENV.fetch('LOG_LEVEL', 'info').to_sym)
 logger.formatter = ->(level, _, _, m) do
   m = {message: m.message, backtrace: m.backtrace.first(5).join("\n")} if m.is_a?(Exception)
   m = {message: m} unless m.is_a?(Hash)
@@ -38,7 +38,7 @@ vault_v2 =
     true_env.include?(ENV["VAULT_KV_V2"])
   end
 
-logger.info message: "Connecting to vault", address: vault_address, v2: vault_v2
+logger.debug message: "Connecting to vault", address: vault_address, v2: vault_v2
 client = SecretsClient.new(
   vault_address: vault_address,
   vault_mount: ENV["VAULT_MOUNT"] || "secret",
@@ -57,7 +57,7 @@ client = SecretsClient.new(
   vault_v2: vault_v2,
   logger: logger
 )
-logger.info message: "WRITE"
+logger.debug message: "WRITE"
 client.write_secrets
 client.write_pki_certs
-logger.info message: "DONE"
+logger.info message: "secrets: DONE"

--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -63,10 +63,10 @@ class SecretsClient
 
     @secret_keys = from_annotations(annotation_lines, /^secret\//)
     raise ArgumentError, "#{annotations} contains no secrets" if @secret_keys.empty?
-    @logger.info(message: "secrets found", keys: @secret_keys)
+    @logger.debug(message: "secrets found", keys: @secret_keys)
 
     @pki_keys = from_annotations(annotation_lines, /^pki\//)
-    @logger.info(message: "PKI found", keys: @pki_keys)
+    @logger.debug(message: "PKI found", keys: @pki_keys)
   end
 
   def write_secrets
@@ -148,7 +148,7 @@ class SecretsClient
         File.write("#{cert_dir}/ca_chain.pem", data[:ca_chain].join("\n"))
       end
     end
-    @logger.info(message: "PKI certificates written")
+    @logger.debug(message: "PKI certificates written")
   end
 
   private
@@ -257,7 +257,7 @@ class SecretsClient
       client.token = secret.auth.client_token
     end
 
-    @logger.info(message: "Authenticated with Vault Server", policies: auth_data.policies, metadata: auth_data.metadata)
+    @logger.debug(message: "Authenticated with Vault Server", policies: auth_data.policies, metadata: auth_data.metadata)
   end
 
   # splits the given url; returning

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -64,7 +64,7 @@ describe SecretsClient do
   let(:status_api_body) { {items: [{status: {hostIP: "10.10.10.10"}}]}.to_json }
 
   before do
-    logger.stubs(:info)
+    logger.stubs(:debug)
     stub_request(:post, "https://foo.bar:8200/v1/auth/cert/login").
       to_return(response_body(auth_reply))
     stub_request(:get, "https://foo.bar:8200/v1/auth/token/lookup-self").
@@ -147,10 +147,10 @@ describe SecretsClient do
     end
 
     it 'logs' do
-      logger.unstub(:info)
-      logger.expects(:info).with(message: "Authenticated with Vault Server", policies: nil, metadata: nil)
-      logger.expects(:info).with(message: "secrets found", keys: [["SECRET", "this/is/very/hidden"]])
-      logger.expects(:info).with(message: "PKI found", keys: []) # ["example.com", "pki/issue/example-com?common_name=example.com"]])
+      logger.unstub(:debug)
+      logger.expects(:debug).with(message: "Authenticated with Vault Server", policies: nil, metadata: nil)
+      logger.expects(:debug).with(message: "secrets found", keys: [["SECRET", "this/is/very/hidden"]])
+      logger.expects(:debug).with(message: "PKI found", keys: []) # ["example.com", "pki/issue/example-com?common_name=example.com"]])
       process_secrets
     end
 


### PR DESCRIPTION
## Problem
Every startup produces logs that have no value for service owners.

```
Connecting to vault
PKI found
Authenticated with Vault Server
secrets found
WRITE
DONE
```

## Solution

1. turn the above logs into debug ones
2. allow configurable log level with LOG_LEVEL env var