### PR TITLE
Bump to ruby:2.6-alpine3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.11
+FROM ruby:2.6-alpine3.13
 
 WORKDIR /app
 


### PR DESCRIPTION
Update alpine base image to fix cve https://security-tracker.debian.org/tracker/CVE-2021-28831