### PR TITLE
bumping alpine version to 3.13 with no vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.11
+FROM ruby:2.6-alpine3.13
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.11
+FROM ruby:2.6-alpine3.13
 
 RUN apk add --update --no-cache bash curl openssl elixir erlang-crypto build-base
 


### PR DESCRIPTION
### Description

Bump base alpine image to 3.13 with no open CVE's

### Risk

Low - no actual code change, just bumping base image for a rebuild to clear security vulns