### PR TITLE
Revert "bumping alpine version to 3.13 with no vuln"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.13
+FROM ruby:2.6-alpine3.11
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.13
+FROM ruby:2.6-alpine3.11
 
 RUN apk add --update --no-cache bash curl openssl elixir erlang-crypto build-base
 


### PR DESCRIPTION
Reverts zendesk/samson_secret_puller#96

lets keep travis green. We've rebuilt a fixed image with the old base image and updated samson/jsonnet-libs

