### PR TITLE
Add RubyGem publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Ruby Gem
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: [ubuntu-latest]
+    environment: rubygems-publish
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby_version }}
+      - name: Install oauth
+        run: |
+          sudo apt-get install --fix-broken --yes oathtool
+      - name: Publish to RubyGems
+        run: |
+          cd gem
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBY_GEMS_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          totp=$(oathtool --base32 --totp "${RUBY_GEMS_TOTP_DEVICE}")
+          gem push *.gem --otp "$totp"
+          rm -rf $HOME/.gem/credentials
+        env:
+          RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+          RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
Adds new workflow to automatically publish new versions to RubyGems. 

Guide: https://github.com/zendesk/gw/tree/main/ruby-gem-publication
Code from: https://github.com/zendesk/gw/blob/main/.github/workflows/ruby-gem-publication.yml

TODO: Once working, we can try to move the gemspec to the root folder and switch to use the reusable workflows (instead of copying the code). It might even be possible to change the dir it uses when packing allowing subfolder.