### PR TITLE
Addressing Elixir test blinker

### DIFF
--- a/elixir/lib/samson_secret_puller.ex
+++ b/elixir/lib/samson_secret_puller.ex
@@ -24,7 +24,7 @@ defmodule SamsonSecretPuller do
 
   ## Examples
 
-      iex> SamsonSecretPuller.fetch_secrets!("./test/doc_secrets")
+      iex> Enum.sort(SamsonSecretPuller.fetch_secrets!("./test/doc_secrets"), :desc)
       [MYSQL_USER: "admin", MYSQL_PASS: "password"]
 
   """


### PR DESCRIPTION
There is a test related blinker on the master branch related to how the secrets enum is being sorted. This sorts the test results in order to make a consistent experience.

[Master test failure](https://github.com/zendesk/samson_secret_puller/actions/runs/8945934543/job/24575862294#step:5:29):
```shell
cd elixir && mix test
Compiling 1 file (.ex)
Generated samson_secret_puller app


  1) doctest SamsonSecretPuller.fetch_secrets!/1 (1) (SamsonSecretPullerTest)
     test/samson_secret_puller_test.exs:4
     Doctest failed
     doctest:
       iex> SamsonSecretPuller.fetch_secrets!("./test/doc_secrets")
       [MYSQL_USER: "admin", MYSQL_PASS: "password"]
     code:  SamsonSecretPuller.fetch_secrets!("./test/doc_secrets") === [MYSQL_USER: "admin", MYSQL_PASS: "password"]
     left:  [MYSQL_PASS: "password", MYSQL_USER: "admin"]
     right: [MYSQL_USER: "admin", MYSQL_PASS: "password"]
     stacktrace:
       lib/samson_secret_puller.ex:[27](https://github.com/zendesk/samson_secret_puller/actions/runs/8945934543/job/24575862294#step:5:28): SamsonSecretPuller (module)

.
Finished in 0.01 seconds (0.00s async, 0.01s sync)
1 doctest, 1 test, 1 failure
```